### PR TITLE
Make faster

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 source "https://rubygems.org"
 
+gem "activesupport"
 gem "auto_paragraph"
+gem "babosa"
+gem "erubis"
+gem "kramdown"
+gem "nanoc", "~> 4.9"
 gem "new_base_60"
+gem "nokogiri"
+gem "sass"
+gem "slim"
+gem "tilt"
+gem "unicode"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,84 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (5.1.5)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     auto_paragraph (1.0.0)
+    babosa (1.0.2)
+    colored (1.2)
+    concurrent-ruby (1.0.5)
+    cri (2.10.1)
+      colored (~> 1.2)
+    ddmemoize (1.0.0)
+      ddmetrics (~> 1.0)
+      ref (~> 2.0)
+    ddmetrics (1.0.0)
+    ddplugin (1.0.1)
+    erubis (2.7.0)
+    ffi (1.9.23)
+    hamster (3.0.0)
+      concurrent-ruby (~> 1.0)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
+    kramdown (1.16.2)
+    mini_portile2 (2.3.0)
+    minitest (5.11.3)
+    nanoc (4.9.1)
+      addressable (~> 2.5)
+      cri (~> 2.8)
+      ddmemoize (~> 1.0)
+      ddmetrics (~> 1.0)
+      ddplugin (~> 1.0)
+      hamster (~> 3.0)
+      parallel (~> 1.12)
+      ref (~> 2.0)
+      slow_enumerator_tools (~> 1.0)
     new_base_60 (1.1.2)
+    nokogiri (1.8.2)
+      mini_portile2 (~> 2.3.0)
+    parallel (1.12.1)
+    public_suffix (3.0.2)
+    rb-fsevent (0.10.3)
+    rb-inotify (0.9.10)
+      ffi (>= 0.5.0, < 2)
+    ref (2.0.0)
+    sass (3.5.5)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    slim (3.0.9)
+      temple (>= 0.7.6, < 0.9)
+      tilt (>= 1.3.3, < 2.1)
+    slow_enumerator_tools (1.1.0)
+    temple (0.8.0)
+    thread_safe (0.3.6)
+    tilt (2.0.8)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
+    unicode (0.4.4.4)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport
   auto_paragraph
+  babosa
+  erubis
+  kramdown
+  nanoc (~> 4.9)
   new_base_60
+  nokogiri
+  sass
+  slim
+  tilt
+  unicode
 
 BUNDLED WITH
-   1.13.6
+   1.16.1

--- a/Rules
+++ b/Rules
@@ -4,7 +4,8 @@ preprocess do
 			'',
 			{
 				title: "Archive for #{year}",
-				posts: ->(ctx) { ctx.send(:by_year, :all_posts)[year] }
+				key: :by_year,
+				value: year,
 			},
 			"/#{year}.html"
 		)
@@ -15,7 +16,8 @@ preprocess do
 			'',
 			{
 				title: "Archive for ##{tag}",
-				posts: ->(ctx) { ctx.send(:by_tag, :all_posts)[tag] }
+				key: :by_tag,
+				value: tag,
 			},
 			"/tags/#{tag}.html"
 		)

--- a/layouts/archive.slim
+++ b/layouts/archive.slim
@@ -11,7 +11,7 @@ section
 	h1 = @item[:title]
 
 	ol.entries
-		- @item[:posts][self].each do |post|
+		- send(@item[:key], :all_posts)[@item[:value]].each do |post|
 			li == render "/feed_item.slim", item: post
 
 == render "/sidebar_and_footer.slim"


### PR DESCRIPTION
This PR changes `Rules` so that the preprocessor no longer stores `Proc`s in attributes. With no changes, the site now compiles in ~20s (rather than > 200s).

I also updated the `Gemfile`, along with `Gemfile.lock`, so that a `bundle install` now installs all dependencies.

* * *

During the outdatedness checking, Nanoc checks whether any attributes have changed. Unfortunately, that’s not reliable for `Proc`s, because they cannot be serialised (its source code isn’t enough, because it also captures variables).

It’s possible for Nanoc to emit a warning when assigning a `Proc` to an attribute. I’ve created an issue for that: nanoc/features/issues/38.